### PR TITLE
Add property to disable in-memory model cache

### DIFF
--- a/src/main/java/eus/ixa/ixa/pipe/lemma/StatisticalLemmatizer.java
+++ b/src/main/java/eus/ixa/ixa/pipe/lemma/StatisticalLemmatizer.java
@@ -60,10 +60,7 @@ public class StatisticalLemmatizer {
    *          the properties object
    */
   public StatisticalLemmatizer(final Properties props) {
-    final String lang = props.getProperty("language");
-    final String model = props.getProperty("lemmatizerModel");
-    final LemmatizerModel lemmatizerModel = loadModel(lang, model);
-    this.lemmatizer = new LemmatizerME(lemmatizerModel);
+    this(props, null);
   }
 
   /**

--- a/src/main/java/eus/ixa/ixa/pipe/lemma/StatisticalLemmatizer.java
+++ b/src/main/java/eus/ixa/ixa/pipe/lemma/StatisticalLemmatizer.java
@@ -152,16 +152,16 @@ public class StatisticalLemmatizer {
    * 
    * @param lang
    *          the language
-   * @param model
+   * @param modelName
    *          the model to be loaded
    * @return the model as a {@link LemmatizerModel} object
    */
-  private LemmatizerModel loadModel(final String lang, final String model) {
+  private LemmatizerModel loadModel(final String lang, final String modelName) {
     final long lStartTime = new Date().getTime();
     try {
       synchronized (lemmaModels) {
         if (!lemmaModels.containsKey(lang)) {
-          lemmaModels.put(lang, new LemmatizerModel(new FileInputStream(model)));
+          lemmaModels.put(lang, new LemmatizerModel(new FileInputStream(modelName)));
         }
       }
     } catch (final IOException e) {

--- a/src/main/java/eus/ixa/ixa/pipe/lemma/StatisticalLemmatizer.java
+++ b/src/main/java/eus/ixa/ixa/pipe/lemma/StatisticalLemmatizer.java
@@ -47,7 +47,7 @@ public class StatisticalLemmatizer {
    * The models to use for every language. The keys of the hashmap are the language
    * codes, the values the models.
    */
-  private static ConcurrentHashMap<String, LemmatizerModel> lemmaModels = new ConcurrentHashMap<String, LemmatizerModel>();
+  private final static ConcurrentHashMap<String, LemmatizerModel> lemmaModels = new ConcurrentHashMap<String, LemmatizerModel>();
   /**
    * The morpho factory.
    */

--- a/src/main/java/eus/ixa/ixa/pipe/pos/StatisticalTagger.java
+++ b/src/main/java/eus/ixa/ixa/pipe/pos/StatisticalTagger.java
@@ -57,10 +57,7 @@ public class StatisticalTagger {
    *          the properties object
    */
   public StatisticalTagger(final Properties props) {
-    final String lang = props.getProperty("language");
-    final String model = props.getProperty("model");
-    final POSModel posModel = loadModel(lang, model);
-    this.posTagger = new POSTaggerME(posModel);
+    this(props, null);
   }
 
   /**

--- a/src/main/java/eus/ixa/ixa/pipe/pos/StatisticalTagger.java
+++ b/src/main/java/eus/ixa/ixa/pipe/pos/StatisticalTagger.java
@@ -44,7 +44,7 @@ public class StatisticalTagger {
    * The models to use for every language. The keys of the hashmap are the language
    * codes, the values the models.
    */
-  private static ConcurrentHashMap<String, POSModel> posModels = new ConcurrentHashMap<String, POSModel>();
+  private final static ConcurrentHashMap<String, POSModel> posModels = new ConcurrentHashMap<String, POSModel>();
   /**
    * The morpho factory.
    */

--- a/src/main/java/eus/ixa/ixa/pipe/pos/StatisticalTagger.java
+++ b/src/main/java/eus/ixa/ixa/pipe/pos/StatisticalTagger.java
@@ -142,16 +142,16 @@ public class StatisticalTagger {
    * 
    * @param lang
    *          the language
-   * @param model
+   * @param modelName
    *          the model to be loaded
    * @return the model as a {@link POSModel} object
    */
-  private POSModel loadModel(final String lang, final String model) {
+  private POSModel loadModel(final String lang, final String modelName) {
     final long lStartTime = new Date().getTime();
     try {
       synchronized (posModels) {
         if (!posModels.containsKey(lang)) {
-          posModels.put(lang, new POSModel(new FileInputStream(model)));
+          posModels.put(lang, new POSModel(new FileInputStream(modelName)));
         }
       }
     } catch (final IOException e) {


### PR DESCRIPTION
Currently, the part-of-speech and lemmatizer models get cached in memory after they've been read from disk. This can lead to very high memory usage, especially if we have a single process that handles requests for many different languages.

This pull request adds a property called `useModelCache` that lets users disable the in-memory caching to reduce the memory usage at the expense of reading more data from disk. By default, the property is enabled so that the public API doesn't change from the previous behavior.