### PR TITLE
recent KafLibVersion to avoid errors with emojis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>com.github.ixa-ehu</groupId>
 			<artifactId>kaflib-naf</artifactId>
-			<version>1.1.15</version>
+			<version>1.1.18</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
When POS tagging emojis in german language I was encountering this Exception. It can be fixed by using the most recent KafLib version.

`Exception in thread "main" org.jdom2.IllegalDataException: The data "?" is not legal for a JDOM attribute: 0xde03 is not a legal XML character.
	at org.jdom2.Attribute.setValue(Attribute.java:487)
	at org.jdom2.Attribute.<init>(Attribute.java:221)
	at org.jdom2.Attribute.<init>(Attribute.java:244)
	at org.jdom2.Element.setAttribute(Element.java:1281)
	at ixa.kaflib.ReadWriteManager.termToDOM(ReadWriteManager.java:2234)
	at ixa.kaflib.ReadWriteManager.KAFToDOM(ReadWriteManager.java:1446)
	at ixa.kaflib.ReadWriteManager.kafToStr(ReadWriteManager.java:83)
	at ixa.kaflib.KAFDocument.toString(KAFDocument.java:1668)
	at eus.ixa.ixa.pipe.pos.StatisticalTaggerServer.getAnnotations(StatisticalTaggerServer.java:192)
	at eus.ixa.ixa.pipe.pos.StatisticalTaggerServer.<init>(StatisticalTaggerServer.java:93)
	at eus.ixa.ixa.pipe.pos.CLI.server(CLI.java:391)
	at eus.ixa.ixa.pipe.pos.CLI.parseCLI(CLI.java:183)
	at eus.ixa.ixa.pipe.pos.CLI.main(CLI.java:157)
`